### PR TITLE
[FEATURE] Improve on config changed

### DIFF
--- a/lib/src/configcat_options.dart
+++ b/lib/src/configcat_options.dart
@@ -2,10 +2,13 @@ import 'package:configcat_client/src/override/flag_overrides.dart';
 import 'package:dio/dio.dart';
 
 import 'configcat_cache.dart';
+import 'configcat_client.dart';
 import 'data_governance.dart';
 import 'log/configcat_logger.dart';
 import 'refresh_policy/polling_mode.dart';
-import 'configcat_client.dart';
+
+/// Represents the config changed callback.
+typedef ConfigChangedHandler = void Function();
 
 /// Configuration options for [ConfigCatClient].
 class ConfigCatOptions {
@@ -19,6 +22,7 @@ class ConfigCatOptions {
   final ConfigCatLogger? logger;
   final FlagOverrides? override;
   final HttpClientAdapter? httpClientAdapter;
+  final ConfigChangedHandler? onConfigChanged;
 
   const ConfigCatOptions({
     this.baseUrl = '',
@@ -31,5 +35,6 @@ class ConfigCatOptions {
     this.sendTimeout = const Duration(seconds: 20),
     this.httpClientAdapter,
     this.override,
+    this.onConfigChanged,
   });
 }

--- a/lib/src/refresh_policy/auto_polling_policy.dart
+++ b/lib/src/refresh_policy/auto_polling_policy.dart
@@ -3,8 +3,8 @@ import 'dart:async';
 import '../config_fetcher.dart';
 import '../json/config.dart';
 import '../json/config_json_cache.dart';
-import '../mixins.dart';
 import '../log/configcat_logger.dart';
+import '../mixins.dart';
 import 'polling_mode.dart';
 import 'refresh_policy.dart';
 
@@ -50,7 +50,6 @@ class AutoPollingPolicy extends DefaultRefreshPolicy
     final response = await fetcher.fetchConfiguration();
     if (response.isFetched) {
       await jsonCache.writeCache(response.config);
-      _config.onConfigChanged?.call();
     }
 
     initialized();

--- a/lib/src/refresh_policy/polling_mode.dart
+++ b/lib/src/refresh_policy/polling_mode.dart
@@ -6,7 +6,6 @@ abstract class PollingMode {
   ///
   /// [autoPollInterval] sets at least how often this policy should fetch the latest configuration and refresh the cache.
   /// [maxInitWaitTime] sets the maximum waiting time between initialization and the first config acquisition in seconds.
-  /// [listener] sets a configuration changed listener.
   factory PollingMode.autoPoll({
     autoPollInterval = const Duration(seconds: 60),
     maxInitWaitTime = const Duration(seconds: 5),

--- a/lib/src/refresh_policy/polling_mode.dart
+++ b/lib/src/refresh_policy/polling_mode.dart
@@ -1,6 +1,3 @@
-/// Represents the config changed callback.
-typedef ConfigChangedHandler = void Function();
-
 /// The base class of a polling mode configuration.
 abstract class PollingMode {
   PollingMode._();
@@ -10,12 +7,14 @@ abstract class PollingMode {
   /// [autoPollInterval] sets at least how often this policy should fetch the latest configuration and refresh the cache.
   /// [maxInitWaitTime] sets the maximum waiting time between initialization and the first config acquisition in seconds.
   /// [listener] sets a configuration changed listener.
-  factory PollingMode.autoPoll(
-      {autoPollInterval = const Duration(seconds: 60),
-      maxInitWaitTime = const Duration(seconds: 5),
-      onConfigChanged}) {
+  factory PollingMode.autoPoll({
+    autoPollInterval = const Duration(seconds: 60),
+    maxInitWaitTime = const Duration(seconds: 5),
+  }) {
     return AutoPollingMode._(
-        autoPollInterval, maxInitWaitTime, onConfigChanged);
+      autoPollInterval,
+      maxInitWaitTime,
+    );
   }
 
   /// Creates a configured lazy loading polling configuration.
@@ -40,11 +39,8 @@ abstract class PollingMode {
 class AutoPollingMode extends PollingMode {
   final Duration autoPollInterval;
   final Duration maxInitWaitTime;
-  final ConfigChangedHandler? onConfigChanged;
 
-  AutoPollingMode._(
-      this.autoPollInterval, this.maxInitWaitTime, this.onConfigChanged)
-      : super._();
+  AutoPollingMode._(this.autoPollInterval, this.maxInitWaitTime) : super._();
 
   @override
   String getPollingIdentifier() {

--- a/test/configcat_fetcher_test.dart
+++ b/test/configcat_fetcher_test.dart
@@ -7,6 +7,7 @@ import 'package:dio/dio.dart';
 import 'package:http_mock_adapter/http_mock_adapter.dart';
 import 'package:sprintf/sprintf.dart';
 import 'package:test/test.dart';
+
 import 'helpers.dart';
 
 void main() {
@@ -393,14 +394,19 @@ void main() {
     });
 
     test('real fetch', () async {
+      bool configChanged = false;
       // Arrange
       final cache = ConfigJsonCache(
           logger: ConfigCatLogger(),
           cache: NullConfigCatCache(),
           sdkKey: testSdkKey);
       final fetcher = _createFetcher(
-          cache: cache,
-          sdkKey: 'PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA');
+        cache: cache,
+        sdkKey: 'PKDVCLf-Hq-h-kCzMp-L7Q/PaDVCFk9EpmD6sLpGLltTA',
+        options: ConfigCatOptions(
+          onConfigChanged: () => configChanged = true,
+        ),
+      );
 
       // Act
       final fetchedResponse = await fetcher.fetchConfiguration();
@@ -408,12 +414,15 @@ void main() {
 
       // Assert
       expect(fetchedResponse.isFetched, isTrue);
+      expect(configChanged, isTrue);
 
+      configChanged = false;
       // Act
       final notModifiedResponse = await fetcher.fetchConfiguration();
 
       // Assert
       expect(notModifiedResponse.isNotModified, isTrue);
+      expect(configChanged, isFalse);
 
       // Cleanup
       fetcher.close();

--- a/test/refresh_policy_test.dart
+++ b/test/refresh_policy_test.dart
@@ -54,11 +54,11 @@ void main() {
       when(fetcher.fetchConfiguration()).thenAnswer((_) => Future.value(
           FetchResponse.success(createTestConfig({'test': 'value'}))));
       when(cache.read(any)).thenAnswer((_) => Future.value(''));
-      var onChanged = false;
+
       final poll = AutoPollingPolicy(
           config: PollingMode.autoPoll(
-              autoPollInterval: Duration(milliseconds: 100),
-              onConfigChanged: () => onChanged = true) as AutoPollingMode,
+            autoPollInterval: Duration(milliseconds: 100),
+          ) as AutoPollingMode,
           fetcher: fetcher,
           logger: logger,
           jsonCache: jsonCache);
@@ -69,7 +69,6 @@ void main() {
       // Assert
       verify(fetcher.fetchConfiguration()).called(greaterThanOrEqualTo(3));
       verify(cache.write(any, any)).called(greaterThanOrEqualTo(3));
-      expect(onChanged, isTrue);
 
       // Cleanup
       poll.close();


### PR DESCRIPTION
### Describe the purpose of your pull request

The current onConfigChange only works in auto poll mode and when the timer runs. If forceRefresh is called and a new config is fetched, onConfigChange is never called.
This change improves moving onConfigChange to ConfigCatOptions and is called every time that a new config is fetched.

### Requirement checklist (only if applicable)

- [X] I have covered the applied changes with automated tests.
- [X] I have executed the full automated test set against my changes.
- [X] I have validated my changes against all supported platform versions.
- [X] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
