### PR TITLE
data governance fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.0.1 - 2022-08-04
+### Fixed
+- When the `dataGovernance` parameter wasn't in match with the remote setting, it could have happened that the fetcher downloaded the correct `config.json` multiple times.  
+
 ## 1.0.0 - 2022-01-24
 - First official release.
 

--- a/lib/src/config_fetcher.dart
+++ b/lib/src/config_fetcher.dart
@@ -133,6 +133,10 @@ class ConfigFetcher
       return response;
     }
 
+    if (preferences.baseUrl.isNotEmpty && _url == preferences.baseUrl) {
+      return response;
+    }
+    
     if (_urlIsCustom && preferences.redirect != _RedirectMode.forceRedirect) {
       return response;
     }

--- a/lib/src/config_fetcher.dart
+++ b/lib/src/config_fetcher.dart
@@ -136,7 +136,7 @@ class ConfigFetcher
     if (preferences.baseUrl.isNotEmpty && _url == preferences.baseUrl) {
       return response;
     }
-    
+
     if (_urlIsCustom && preferences.redirect != _RedirectMode.forceRedirect) {
       return response;
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: configcat_client
 description: >-
   Dart (Flutter) SDK for ConfigCat. ConfigCat is a hosted feature flag service that lets you manage feature toggles across frontend, backend, mobile, desktop apps.
-version: 1.0.0
+version: 1.0.1
 homepage: https://configcat.com/docs/sdk-reference/dart
 repository: https://github.com/configcat/dart-sdk
 issue_tracker: https://github.com/configcat/dart-sdk/issues


### PR DESCRIPTION
Data Governance fix:
If the preferences baseUrl is the same as the last called one, just return the response.

### Requirement checklist (only if applicable)

- [ ] I have covered the applied changes with automated tests.
- [ ] I have executed the full automated test set against my changes.
- [ ] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
