### PR TITLE
Fix web platform support & send etag and SDK info in query params in case of web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.0.1 - 2024-02-13
+### Fixed
+- `WEB` platform support.
+
+### Changed
+- In case of `WEB` platform the SDK now sends the Etag and SDK info in query parameters.
+
 ## 4.0.0 - 2024-02-13
 ### New features and improvements
 - Add support for the new Config JSON v6 format: update the config model and implement new features in setting evaluation logic.

--- a/lib/src/evaluate_logger.dart
+++ b/lib/src/evaluate_logger.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:configcat_client/src/utils.dart';
+import 'package:configcat_client/src/platform_spec/platform.dart';
 
 import '../configcat_client.dart';
 import 'json/prerequisite_comparator.dart';
@@ -31,7 +31,7 @@ class EvaluateLogger {
   }
 
   newLine() {
-    _stringBuffer.write(Utils.lineTerminator);
+    _stringBuffer.write(Platform.lineTerminator);
     for (int i = 0; i < _indentLevel; i++) {
       _stringBuffer.write("  ");
     }

--- a/lib/src/platform_spec/default/platform.dart
+++ b/lib/src/platform_spec/default/platform.dart
@@ -1,0 +1,4 @@
+class ActualPlatform {
+  ActualPlatform._();
+  static String get lineTerminator => '\n';
+}

--- a/lib/src/platform_spec/default/request_builder.dart
+++ b/lib/src/platform_spec/default/request_builder.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+
+class ActualRequestBuilder {
+  static const _userAgentHeaderName = 'X-ConfigCat-UserAgent';
+  static const _ifNoneMatchHeaderName = 'If-None-Match';
+
+  ActualRequestBuilder._();
+
+  static RequestOptions build(String sdkInfo, String etag) {
+    Map<String, String> headers = {
+      _userAgentHeaderName: sdkInfo,
+      if (etag.isNotEmpty) _ifNoneMatchHeaderName: etag
+    };
+
+    return RequestOptions(headers: headers);
+  }
+}

--- a/lib/src/platform_spec/io/platform.dart
+++ b/lib/src/platform_spec/io/platform.dart
@@ -1,0 +1,6 @@
+import 'dart:io';
+
+class ActualPlatform {
+  ActualPlatform._();
+  static String get lineTerminator => Platform.isWindows ? '\r\n' : '\n';
+}

--- a/lib/src/platform_spec/platform.dart
+++ b/lib/src/platform_spec/platform.dart
@@ -1,0 +1,6 @@
+import 'default/platform.dart' if (dart.library.io) 'io/platform.dart';
+
+class Platform {
+  Platform._();
+  static String get lineTerminator => ActualPlatform.lineTerminator;
+}

--- a/lib/src/platform_spec/request_builder.dart
+++ b/lib/src/platform_spec/request_builder.dart
@@ -1,0 +1,12 @@
+import 'package:dio/dio.dart';
+
+import 'default/request_builder.dart'
+    if (dart.library.html) 'web/request_builder.dart';
+
+class RequestBuilder {
+  RequestBuilder._();
+
+  static RequestOptions build(String sdkInfo, String etag) {
+    return ActualRequestBuilder.build(sdkInfo, etag);
+  }
+}

--- a/lib/src/platform_spec/web/request_builder.dart
+++ b/lib/src/platform_spec/web/request_builder.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+
+class ActualRequestBuilder {
+  static const _sdkInfoName = 'sdk';
+  static const _ccEtagName = 'ccetag';
+
+  ActualRequestBuilder._();
+
+  static RequestOptions build(String sdkInfo, String etag) {
+    Map<String, String> queryParams = {
+      _sdkInfoName: sdkInfo,
+      if (etag.isNotEmpty) _ccEtagName: etag
+    };
+
+    return RequestOptions(queryParameters: queryParams);
+  }
+}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 
 import '../configcat_client.dart';
 
@@ -18,10 +17,6 @@ class Utils {
     }
     return config;
   }
-
-  // Copy of the implementation of `Platform.lineTerminator`, which is available only since Dart 3.2.0 (see also https://stackoverflow.com/a/77295824/8656352)
-  @pragma("vm:platform-const")
-  static String get lineTerminator => Platform.isWindows ? '\r\n' : '\n';
 
   // Dart syntax doesn't allow expressions like `T == int?` because that conflicts with ternary operator syntax.
   // This is a workaround for that limitation (see also https://stackoverflow.com/a/73120173/8656352)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   crypto: ^3.0.3
-  dio: "^5.0.0"
+  dio: ^5.0.0
   pub_semver: ^2.1.4
   json_annotation: ^4.8.1
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: configcat_client
 description: >-
   Dart (Flutter) SDK for ConfigCat. ConfigCat is a hosted feature flag service that lets you manage feature toggles across frontend, backend, mobile, desktop apps.
-version: 4.0.0
+version: 4.0.1
 homepage: https://configcat.com/docs/sdk-reference/dart
 repository: https://github.com/configcat/dart-sdk
 issue_tracker: https://github.com/configcat/dart-sdk/issues


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fixed `WEB` platform support.
- In the case of `WEB` platform, the SDK now sends the Etag and SDK info in query parameters.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
