### PR TITLE
Fix auto poll initial config load from cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.1 - 2024-05-06
+### Fixed
+- Fix initial config JSON load when auto poll enabled with results from cache.
+
 ## 4.1.0 - 2024-04-03
 ### Changed
 - Rename `SettingsValue` to correct `SettingValue`

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,4 +1,4 @@
-const version = '4.1.0';
+const version = '4.1.1';
 const configJsonCacheVersion = 'v2';
 const configJsonName = 'config_v6.json';
 final DateTime distantPast = DateTime.utc(1970, 01, 01);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: configcat_client
 description: >-
   Dart (Flutter) SDK for ConfigCat. ConfigCat is a hosted feature flag service that lets you manage feature toggles across frontend, backend, mobile, desktop apps.
-version: 4.1.0
+version: 4.1.1
 homepage: https://configcat.com/docs/sdk-reference/dart
 repository: https://github.com/configcat/dart-sdk
 issue_tracker: https://github.com/configcat/dart-sdk/issues


### PR DESCRIPTION
### Describe the purpose of your pull request

- Fix initial config JSON load when auto poll enabled with results from cache.

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
